### PR TITLE
Fall back to path when package.json is missing name

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ async function* loadIssues(paths) {
   for (const chunk of chunksOfSize(paths, MAX_CONCURRENT_REQUESTS)) {
     const promises = chunk.map(async (path) => {
       const json = require(path);
-      const { name, repository } = json;
+      let { name, repository } = json;
+      // Not all package.json files include a `name`, fall back to `path`
+      name = name || path;
       if (!repository) {
         return { name, rateLimitExceeded };
       }


### PR DESCRIPTION
Fixes #3.  This adds a fallback to the `path` of the `package.json` file when the package is missing a `name` field.

You can test this by adding a package that includes `package.json` files without `name`, for example:

```sh
npm install date-fns
npx shoulders
```

With this change you get lines like this instead of `undefined`:

```
...
/Users/humphd/repos/shoulders/node_modules/date-fns/esm/locale/sk/package.json
No issues found.

/Users/humphd/repos/shoulders/node_modules/date-fns/esm/locale/sl/package.json
No issues found.
...
```